### PR TITLE
fix(api): reset server URL to vwip on main (fixes #18)

### DIFF
--- a/code/API_definitions/media-streaming-rate.yaml
+++ b/code/API_definitions/media-streaming-rate.yaml
@@ -82,7 +82,7 @@ externalDocs:
   url: https://github.com/camaraproject/DeviceQualityIndicator
 
 servers:
-  - url: "{apiRoot}/media-streaming-rate/wip"
+  - url: "{apiRoot}/media-streaming-rate/vwip"
     variables:
       apiRoot:
         default: http://localhost:8087


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

- updates the OpenAPI server URL in `code/API_definitions/media-streaming-rate.yaml` from `{apiRoot}/media-streaming-rate/wip` to `{apiRoot}/media-streaming-rate/vwip`
- keeps `info.version` as `wip` (already correct on `main`)
- ensures `main` follows CAMARA `vwip` URL convention and serves as a prerequisite for Release Automation onboarding

#### Which issue(s) this PR fixes:

Fixes #18

#### Special notes for reviewers:

- this repository currently has no `.feature` test definition files under `code/Test_definitions`, so no test-file version/path updates are included

#### Changelog input

```
 release-note
Correction: reset server URL path segment from /wip to /vwip in main branch OpenAPI definition.
```

#### Additional documentation 

```
docs
N/A
```
