### PR TITLE
Modify release plan for pre-release

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -40,10 +40,10 @@ apis:
       - maxl2287
       - sachinvodafone
       - maheshc01
-  - api_name: media-streaming-rate-subscriptions
-    target_api_version: 0.1.0
-    target_api_status: draft
-    main_contacts:
-      - maxl2287
-      - sachinvodafone
-      - maheshc01
+#  - api_name: media-streaming-rate-subscriptions
+#    target_api_version: 0.1.0
+#    target_api_status: alpha
+#    main_contacts:
+#      - maxl2287
+#      - sachinvodafone
+#      - maheshc01

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,23 +20,31 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: none
+  target_release_type: pre-release-alpha
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r3.4
-  identity_consent_management_release: r3.3
+  commonalities_release: r4.2
+  identity_consent_management_release: r4.2
 
 # APIs in this repository
 # Replace the placeholder below when planning a release:
 # - api_name: kebab-case identifier (used as filename in code/API_definitions/)
 # - target_api_status: draft | alpha | rc | public (draft allows no file yet)
 apis:
-  - api_name: placeholder-entry
+  - api_name: media-streaming-rate
     target_api_version: 0.1.0
-    target_api_status: draft
+    target_api_status: alpha
     main_contacts:
       - maxl2287
       - sachinvodafone
       - maheshc01
+  - api_name: media-streaming-rate-subscriptions
+    target_api_version: 0.1.0
+    target_api_status: alpha
+    main_contacts:
+      - maxl2287
+      - sachinvodafone
+      - maheshc01
+      

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -42,9 +42,8 @@ apis:
       - maheshc01
   - api_name: media-streaming-rate-subscriptions
     target_api_version: 0.1.0
-    target_api_status: alpha
+    target_api_status: draft
     main_contacts:
       - maxl2287
       - sachinvodafone
       - maheshc01
-      


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* repository management


#### What this PR does / why we need it:

It is recommended (or even required) to create independent release before participation in the next meta-release (Sync26).
The dependencies are updated to the latest ICM and Commonalities releases.


#### Which issue(s) this PR fixes:

Fixes # N/A

#### Special notes for reviewers:

For `media-streaming-rate` the target is
```
    target_api_version: 0.1.0
    target_api_status: alpha
```

Subscription API is proposed in https://github.com/camaraproject/DeviceMediaStreamingRate/pull/17 `media-streaming-rate-subscriptions`  is added as comment
```
    target_api_version: 0.1.0
    target_api_status: alpha
```

#### Changelog input

```
Update release plan for independent release.
```

#### Additional documentation 

[CAMARA Release Process Documentation](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/README.md)

